### PR TITLE
Fix leaked transactions: ROLLBACK before early returns in report mutations

### DIFF
--- a/backend/src/services/points.service.js
+++ b/backend/src/services/points.service.js
@@ -146,7 +146,10 @@ const updateReport = async ({ reportId, userId, status, comment, imageUrls, obse
       'SELECT * FROM reports WHERE id = $1 AND user_id = $2',
       [reportId, userId]
     );
-    if (existing.rows.length === 0) return null;
+    if (existing.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return null;
+    }
 
     const legacyImageUrl = imageUrls && imageUrls.length > 0 ? imageUrls[0] : existing.rows[0].image_url;
 
@@ -198,7 +201,10 @@ const deleteReport = async ({ reportId, userId }) => {
       'SELECT * FROM reports WHERE id = $1 AND user_id = $2',
       [reportId, userId]
     );
-    if (existing.rows.length === 0) return false;
+    if (existing.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return false;
+    }
 
     const pointId = existing.rows[0].point_id;
 
@@ -361,7 +367,10 @@ const deleteReportImage = async ({ reportId, imageId, userId }) => {
       'SELECT id FROM reports WHERE id = $1 AND user_id = $2',
       [reportId, userId]
     );
-    if (reportCheck.rows.length === 0) return null;
+    if (reportCheck.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return null;
+    }
 
     const imgResult = await client.query(
       'DELETE FROM report_images WHERE id = $1 AND report_id = $2 RETURNING image_url',


### PR DESCRIPTION
Fixes #12.

## Problem
`updateReport`, `deleteReport`, and `deleteReportImage` in `backend/src/services/points.service.js` opened a transaction with `BEGIN`, then returned early when the report-ownership check failed — without `ROLLBACK`. The `finally { client.release(); }` returned the connection to the pool **still inside an open transaction** ("idle in transaction"):

- the next request checking out that connection silently ran inside the stale transaction (old snapshot, "there is already a transaction in progress" warnings),
- autovacuum was blocked while the connection sat idle,
- a later unrelated `ROLLBACK` on that connection could discard work that appeared committed.

This was triggered any time a user hit `PUT/DELETE /api/points/:id/reports/:reportId` for a report that wasn't theirs.

## Fix
`await client.query('ROLLBACK')` before each early return — the same pattern the image-existence check in `deleteReportImage` already used. `addReportToPoint` (the fourth transactional function) was verified clean: it only returns after `COMMIT`.

## Verification
- `node --check` passes on the edited file.
- All four `BEGIN` sites in the file audited: every code path now ends in `COMMIT` or `ROLLBACK`.

https://claude.ai/code/session_01R3wbjYDgQYeKNbUKpeTzMh

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3wbjYDgQYeKNbUKpeTzMh)_